### PR TITLE
Changed plugin display name to cause less confusion

### DIFF
--- a/nivo-slider-lite.php
+++ b/nivo-slider-lite.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: Slider by Nivo - Responsive Image Slider
+ * Plugin Name: Nivo Slider Lite
  * Plugin URI: https://themeisle.com/plugins/nivo-slider-lite
  * Description: Nivo Slider is The Most Popular And Easiest to Use WordPress Slider Plugin.
  * Version: 2.1.1

--- a/nivo-slider-lite.php
+++ b/nivo-slider-lite.php
@@ -3,7 +3,7 @@
  * Plugin Name: Nivo Slider Lite
  * Plugin URI: https://themeisle.com/plugins/nivo-slider-lite
  * Description: Nivo Slider is The Most Popular And Easiest to Use WordPress Slider Plugin.
- * Version: 2.1.1
+ * Version: 2.1.2
  * Author: ThemeIsle
  * Author URI: https://themeisle.com/
  * Text Domain: nivo-slider

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,5 @@
 === Slider by Nivo - Responsive WordPress Image Slider ===
+Plugin Name: Slider by Nivo - Responsive Image Slider
 Contributors: themeisle, codeinwp, nivoslider
 Tags: slider, nivo,slider plugin, slideshow, slideshow plugin, template tag, wordpress gallery, wordpress image slider, wordpress photo gallery
 Requires at least: 3.0


### PR DESCRIPTION
@selul @ineagu https://secure.helpscout.net/conversation/510458894/152981?folderId=847188

Because the Pro and the Lite plugin had different names displayed in the plugins area of WordPress it can be confusing, especially since there are many Nivo plugins out there