### PR TITLE
Minor change to support media library extensions

### DIFF
--- a/assets/js/image-admin.js
+++ b/assets/js/image-admin.js
@@ -270,8 +270,11 @@ jQuery( document ).ready(function($){
 					text: editing ? wp.media.view.l10n.updateGallery : wp.media.view.l10n.insertGallery,
 
 					click: function() {
-						var models = frame.state().get( 'library' ),
+						var state = frame.state(),
+							models = state.get('library'),
 							ids = '';
+
+						state.trigger( 'update', models );
 
 						models.each( function( attachment ) {
 							ids += attachment.id + ','


### PR DESCRIPTION
I am suggesting adding the firing of update event for when performing a gallery insert. This not only make it consistent with the native wordpress gallery insert object it overrides (https://github.com/WordPress/WordPress/blob/master/wp-includes/js/media-views.js#L3930), but also allows plugins that extends the media library like the Remote Media Libraries Suite of plugins to work properly with the Nivo Slider.
Thanks for taking a look at this.